### PR TITLE
Preserve the order of attributes

### DIFF
--- a/crates/brace-web-markup/Cargo.toml
+++ b/crates/brace-web-markup/Cargo.toml
@@ -6,3 +6,6 @@ description = "A web application markup templating engine."
 repository = "https://github.com/brace-rs/brace-web"
 license = "MIT OR Apache-2.0"
 edition = "2018"
+
+[dependencies]
+indexmap = "1.2"

--- a/crates/brace-web-markup/src/node/element.rs
+++ b/crates/brace-web-markup/src/node/element.rs
@@ -1,4 +1,4 @@
-use std::collections::hash_map::{HashMap, IntoIter, Iter, IterMut};
+use indexmap::map::{IndexMap, IntoIter, Iter, IterMut};
 
 use super::Nodes;
 
@@ -85,11 +85,11 @@ impl From<String> for Element {
 }
 
 #[derive(Clone, Default)]
-pub struct Attrs(HashMap<String, String>);
+pub struct Attrs(IndexMap<String, String>);
 
 impl Attrs {
     pub fn new() -> Self {
-        Self(HashMap::new())
+        Self(IndexMap::new())
     }
 
     pub fn get<K>(&self, key: K) -> Option<&String>
@@ -119,7 +119,7 @@ impl Attrs {
     where
         K: AsRef<str>,
     {
-        self.0.remove(key.as_ref());
+        self.0.swap_remove(key.as_ref());
         self
     }
 


### PR DESCRIPTION
This preserves the order of attributes by replacing the core _hashmap_ implementation with that of the _indexmap_ crate. This will be important in future updates.