### PR TITLE
Add basic markup html rendering

### DIFF
--- a/crates/brace-web-markup/src/lib.rs
+++ b/crates/brace-web-markup/src/lib.rs
@@ -3,3 +3,4 @@ pub use crate::node::text::Text;
 pub use crate::node::Node;
 
 pub mod node;
+pub mod render;

--- a/crates/brace-web-markup/src/node/element.rs
+++ b/crates/brace-web-markup/src/node/element.rs
@@ -1,6 +1,9 @@
+use std::fmt::Write;
+
 use indexmap::map::{IndexMap, IntoIter, Iter, IterMut};
 
 use super::Nodes;
+use crate::render::{Render, Renderer, Result as RenderResult};
 
 pub fn element<T, A, N>(tag: T, attrs: A, nodes: N) -> Element
 where
@@ -61,6 +64,26 @@ impl Element {
 
     pub fn nodes_mut(&mut self) -> &mut Nodes {
         &mut self.nodes
+    }
+}
+
+impl Render for Element {
+    fn render(&self, renderer: &mut Renderer) -> RenderResult {
+        write!(renderer, "<{}", self.tag)?;
+
+        for (key, val) in &self.attrs {
+            write!(renderer, " {}=\"{}\"", key, val)?;
+        }
+
+        write!(renderer, ">")?;
+
+        for node in &self.nodes {
+            node.render(renderer)?;
+        }
+
+        write!(renderer, "</{}>", self.tag)?;
+
+        Ok(())
     }
 }
 

--- a/crates/brace-web-markup/src/node/mod.rs
+++ b/crates/brace-web-markup/src/node/mod.rs
@@ -2,6 +2,7 @@ use std::collections::vec_deque::{IntoIter, Iter, IterMut, VecDeque};
 
 use self::element::Element;
 use self::text::Text;
+use crate::render::{Render, Renderer, Result as RenderResult};
 
 pub mod element;
 pub mod text;
@@ -66,6 +67,15 @@ impl Node {
         match self {
             Self::Element(element) => Some(element),
             _ => None,
+        }
+    }
+}
+
+impl Render for Node {
+    fn render(&self, renderer: &mut Renderer) -> RenderResult {
+        match self {
+            Self::Text(text) => text.render(renderer),
+            Self::Element(element) => element.render(renderer),
         }
     }
 }

--- a/crates/brace-web-markup/src/node/text.rs
+++ b/crates/brace-web-markup/src/node/text.rs
@@ -1,3 +1,7 @@
+use std::fmt::Write;
+
+use crate::render::{Render, Renderer, Result as RenderResult};
+
 pub fn text<T>(text: T) -> Text
 where
     T: Into<String>,
@@ -22,6 +26,12 @@ impl Text {
 
     pub fn value_mut(&mut self) -> &mut String {
         &mut self.0
+    }
+}
+
+impl Render for Text {
+    fn render(&self, renderer: &mut Renderer) -> RenderResult {
+        Ok(write!(renderer, "{}", self.0)?)
     }
 }
 

--- a/crates/brace-web-markup/src/render.rs
+++ b/crates/brace-web-markup/src/render.rs
@@ -1,0 +1,120 @@
+use std::error::Error as StdError;
+use std::fmt::{Display, Error as FmtError, Formatter, Result as FmtResult, Write};
+use std::result::Result as StdResult;
+
+pub type Result = StdResult<(), Error>;
+
+pub fn render<T>(item: T) -> StdResult<String, Error>
+where
+    T: Render,
+{
+    let mut buffer = String::new();
+    let mut renderer = Renderer::new(&mut buffer);
+
+    renderer.render(item)?;
+
+    Ok(buffer)
+}
+
+pub trait Render {
+    fn render(&self, renderer: &mut Renderer) -> Result;
+}
+
+pub struct Renderer<'a>(&'a mut (dyn Write + 'a));
+
+impl<'a> Renderer<'a> {
+    pub fn new<T>(buffer: &'a mut T) -> Self
+    where
+        T: Write,
+    {
+        Self(buffer)
+    }
+
+    pub fn render<T>(&mut self, item: T) -> Result
+    where
+        T: Render,
+    {
+        item.render(self)
+    }
+}
+
+impl Write for Renderer<'_> {
+    fn write_str(&mut self, s: &str) -> FmtResult {
+        self.0.write_str(s)
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Message(String),
+    Format(FmtError),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        match self {
+            Self::Message(message) => write!(f, "{}", message),
+            Self::Format(error) => write!(f, "{}", error),
+        }
+    }
+}
+
+impl StdError for Error {}
+
+impl From<FmtError> for Error {
+    fn from(from: FmtError) -> Self {
+        Self::Format(from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render;
+    use crate::{Element, Node};
+
+    #[test]
+    fn test_render_node() {
+        let node_1 = Node::element("html");
+
+        assert_eq!(render(node_1).unwrap(), "<html></html>");
+
+        let mut node_2 = Node::element("html");
+
+        node_2
+            .as_element_mut()
+            .unwrap()
+            .attrs_mut()
+            .insert("xmlns", "http://www.w3.org/1999/xhtml");
+
+        node_2
+            .as_element_mut()
+            .unwrap()
+            .nodes_mut()
+            .append(Node::element(Element::with(
+                "head",
+                (),
+                Element::with("title", (), "Hello world"),
+            )))
+            .append(Node::element(Element::with("body", (), "hello world")));
+
+        assert_eq!(
+            render(node_2).unwrap(),
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Hello world</title></head><body>hello world</body></html>"
+        );
+
+        let mut node_3 = Node::element("div");
+
+        node_3
+            .as_element_mut()
+            .unwrap()
+            .attrs_mut()
+            .insert("b", "1")
+            .insert("a", "2")
+            .insert("c", "3");
+
+        assert_eq!(
+            render(node_3).unwrap(),
+            "<div b=\"1\" a=\"2\" c=\"3\"></div>"
+        );
+    }
+}


### PR DESCRIPTION
This adds a simplified html rendering system for markup nodes. Future work needs to be done to address rendering to xml and to support self-closing tags.