### PR TITLE
Unify markup element tag, nodes and attributes

### DIFF
--- a/crates/brace-web-markup/Cargo.toml
+++ b/crates/brace-web-markup/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2018"
 
 [dependencies]
 indexmap = "1.2"
+lazy_static = "1.4"

--- a/crates/brace-web-markup/src/node/element/attribute.rs
+++ b/crates/brace-web-markup/src/node/element/attribute.rs
@@ -1,9 +1,12 @@
 use indexmap::map::{IndexMap, IntoIter, Iter, IterMut};
 
+use crate::node::Nodes;
+
 #[derive(Clone)]
 pub enum Attr {
     String(String),
     Boolean(bool),
+    Nodes(Nodes),
 }
 
 impl Attr {
@@ -62,6 +65,34 @@ impl Attr {
             _ => None,
         }
     }
+
+    pub fn nodes<T>(nodes: T) -> Self
+    where
+        T: Into<Nodes>,
+    {
+        Self::Nodes(nodes.into())
+    }
+
+    pub fn is_nodes(&self) -> bool {
+        match self {
+            Self::Nodes(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn as_nodes(&self) -> Option<&Nodes> {
+        match self {
+            Self::Nodes(nodes) => Some(nodes),
+            _ => None,
+        }
+    }
+
+    pub fn as_nodes_mut(&mut self) -> Option<&mut Nodes> {
+        match self {
+            Self::Nodes(nodes) => Some(nodes),
+            _ => None,
+        }
+    }
 }
 
 impl From<&str> for Attr {
@@ -83,7 +114,7 @@ impl From<bool> for Attr {
 }
 
 #[derive(Clone, Default)]
-pub struct Attrs(IndexMap<String, Attr>);
+pub struct Attrs(pub(crate) IndexMap<String, Attr>);
 
 impl Attrs {
     pub fn new() -> Self {

--- a/crates/brace-web-markup/src/node/element/attribute.rs
+++ b/crates/brace-web-markup/src/node/element/attribute.rs
@@ -1,6 +1,8 @@
 use indexmap::map::{IndexMap, IntoIter, Iter, IterMut};
 
-use crate::node::Nodes;
+use crate::node::element::Element;
+use crate::node::text::Text;
+use crate::node::{Node, Nodes};
 
 #[derive(Clone)]
 pub enum Attr {
@@ -110,6 +112,48 @@ impl From<String> for Attr {
 impl From<bool> for Attr {
     fn from(from: bool) -> Self {
         Self::Boolean(from)
+    }
+}
+
+impl From<Text> for Attr {
+    fn from(from: Text) -> Self {
+        Self::Nodes(from.into())
+    }
+}
+
+impl From<Vec<Text>> for Attr {
+    fn from(from: Vec<Text>) -> Self {
+        Self::Nodes(from.into())
+    }
+}
+
+impl From<Element> for Attr {
+    fn from(from: Element) -> Self {
+        Self::Nodes(from.into())
+    }
+}
+
+impl From<Vec<Element>> for Attr {
+    fn from(from: Vec<Element>) -> Self {
+        Self::Nodes(from.into())
+    }
+}
+
+impl From<Node> for Attr {
+    fn from(from: Node) -> Self {
+        Self::Nodes(from.into())
+    }
+}
+
+impl From<Vec<Node>> for Attr {
+    fn from(from: Vec<Node>) -> Self {
+        Self::Nodes(from.into())
+    }
+}
+
+impl From<Nodes> for Attr {
+    fn from(from: Nodes) -> Self {
+        Self::Nodes(from)
     }
 }
 

--- a/crates/brace-web-markup/src/node/element/mod.rs
+++ b/crates/brace-web-markup/src/node/element/mod.rs
@@ -85,6 +85,38 @@ impl Element {
             .as_nodes_mut()
             .unwrap()
     }
+
+    pub fn get<K>(&self, key: K) -> Option<&Attr>
+    where
+        K: AsRef<str>,
+    {
+        self.0.get(key.as_ref())
+    }
+
+    pub fn get_mut<K>(&mut self, key: K) -> Option<&mut Attr>
+    where
+        K: AsRef<str>,
+    {
+        self.0.get_mut(key.as_ref())
+    }
+
+    pub fn set<K, V>(&mut self, key: K, val: V) -> &mut Self
+    where
+        K: Into<String>,
+        V: Into<Attr>,
+    {
+        self.0.insert(key, val);
+        self
+    }
+
+    pub fn attr<K, V>(mut self, key: K, val: V) -> Self
+    where
+        K: Into<String>,
+        V: Into<Attr>,
+    {
+        self.0.insert(key, val);
+        self
+    }
 }
 
 impl Render for Element {
@@ -131,7 +163,7 @@ impl From<String> for Element {
 
 #[cfg(test)]
 mod tests {
-    use super::Element;
+    use crate::{Element, Text};
 
     #[test]
     fn test_element_attribute_string() {
@@ -177,5 +209,46 @@ mod tests {
                 .unwrap(),
             false
         );
+    }
+
+    #[test]
+    fn test_element_impl() {
+        let element = Element::new("div")
+            .attr("id", "test")
+            .attr("class", "testing")
+            .attr(
+                "nodes",
+                vec![
+                    Element::new("span")
+                        .attr("class", "one")
+                        .attr("nodes", Text::new("one")),
+                    Element::new("span")
+                        .attr("class", "two")
+                        .attr("nodes", Text::new("two")),
+                ],
+            );
+
+        assert_eq!(element.nodes().len(), 2);
+        assert_eq!(element.tag(), "div");
+        assert_eq!(element.get("tag").unwrap().as_string().unwrap(), "div");
+        assert_eq!(element.get("id").unwrap().as_string().unwrap(), "test");
+        assert_eq!(
+            element.get("class").unwrap().as_string().unwrap(),
+            "testing"
+        );
+
+        let node_1 = element.nodes().get(0).unwrap().as_element().unwrap();
+
+        assert_eq!(node_1.nodes().len(), 1);
+        assert_eq!(node_1.tag(), "span");
+        assert_eq!(node_1.get("tag").unwrap().as_string().unwrap(), "span");
+        assert_eq!(node_1.get("class").unwrap().as_string().unwrap(), "one");
+
+        let node_2 = element.nodes().get(1).unwrap().as_element().unwrap();
+
+        assert_eq!(node_2.nodes().len(), 1);
+        assert_eq!(node_2.tag(), "span");
+        assert_eq!(node_2.get("tag").unwrap().as_string().unwrap(), "span");
+        assert_eq!(node_2.get("class").unwrap().as_string().unwrap(), "two");
     }
 }

--- a/crates/brace-web-markup/src/node/mod.rs
+++ b/crates/brace-web-markup/src/node/mod.rs
@@ -197,9 +197,21 @@ impl From<Text> for Nodes {
     }
 }
 
+impl From<Vec<Text>> for Nodes {
+    fn from(from: Vec<Text>) -> Self {
+        Self(from.into_iter().map(Node::from).collect())
+    }
+}
+
 impl From<Element> for Nodes {
     fn from(from: Element) -> Self {
         Self(vec![Node::from(from)].into())
+    }
+}
+
+impl From<Vec<Element>> for Nodes {
+    fn from(from: Vec<Element>) -> Self {
+        Self(from.into_iter().map(Node::from).collect())
     }
 }
 


### PR DESCRIPTION
This unifies the tag, nodes and attributes of a markup element as a single collection such that the tag and nodes become special attributes and elements become attribute wrappers. Although this is not how they are treated in HTML this will eventually allow for custom rendered components that accept arbitrary data as attributes/properties.