### PR TITLE
Introduce a none markup element attribute

### DIFF
--- a/crates/brace-web-markup/src/node/element/attribute.rs
+++ b/crates/brace-web-markup/src/node/element/attribute.rs
@@ -97,7 +97,7 @@ impl Attr {
         }
     }
 
-    pub fn none() -> Self {
+    pub const fn none() -> Self {
         Self::None
     }
 

--- a/crates/brace-web-markup/src/node/element/attribute.rs
+++ b/crates/brace-web-markup/src/node/element/attribute.rs
@@ -9,6 +9,7 @@ pub enum Attr {
     String(String),
     Boolean(bool),
     Nodes(Nodes),
+    None,
 }
 
 impl Attr {
@@ -94,6 +95,23 @@ impl Attr {
             Self::Nodes(nodes) => Some(nodes),
             _ => None,
         }
+    }
+
+    pub fn none() -> Self {
+        Self::None
+    }
+
+    pub fn is_none(&self) -> bool {
+        match self {
+            Self::None => true,
+            _ => false,
+        }
+    }
+}
+
+impl From<()> for Attr {
+    fn from(_: ()) -> Self {
+        Self::None
     }
 }
 

--- a/crates/brace-web-markup/src/node/element/mod.rs
+++ b/crates/brace-web-markup/src/node/element/mod.rs
@@ -212,6 +212,18 @@ mod tests {
     }
 
     #[test]
+    fn test_element_attribute_none() {
+        let mut element_1 = Element::new("div");
+        let mut element_2 = Element::with("div", (), ());
+
+        element_1.attrs_mut().insert("attr", ());
+        element_2.attrs_mut().insert("attr", ());
+
+        assert!(element_1.attrs().get("attr").unwrap().is_none());
+        assert!(element_2.attrs().get("attr").unwrap().is_none());
+    }
+
+    #[test]
     fn test_element_impl() {
         let element = Element::new("div")
             .attr("id", "test")


### PR DESCRIPTION
This adds an _enum_ variant for _None_ which is represented by the unit type. Note that this was originally going to be named _Empty_ but the HTML specification for empty attributes defines them as boolean attributes that equate to true.