### PR TITLE
Export markup crate from base crate feature

### DIFF
--- a/crates/brace-web/Cargo.toml
+++ b/crates/brace-web/Cargo.toml
@@ -6,3 +6,10 @@ description = "A web application framework."
 repository = "https://github.com/brace-rs/brace-web"
 license = "MIT OR Apache-2.0"
 edition = "2018"
+
+[features]
+default = ["markup"]
+markup = ["brace-web-markup"]
+
+[dependencies]
+brace-web-markup = { path = "../brace-web-markup", optional = true }

--- a/crates/brace-web/src/lib.rs
+++ b/crates/brace-web/src/lib.rs
@@ -1,7 +1,2 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+#[cfg(feature = "markup")]
+pub use brace_web_markup as markup;


### PR DESCRIPTION
This gives the base crate a purpose by re-exporting the `markup` crate under the `markup` feature which is set as a default.