### PR TITLE
Add core crate exporting actix-web

### DIFF
--- a/crates/brace-web-core/Cargo.toml
+++ b/crates/brace-web-core/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "brace-web-core"
+version = "0.1.0"
+authors = ["Daniel Balcomb <daniel.balcomb@gmail.com>"]
+description = "The web application framework core."
+repository = "https://github.com/brace-rs/brace-web"
+license = "MIT OR Apache-2.0"
+edition = "2018"
+
+[dependencies]
+actix-web = "2.0"

--- a/crates/brace-web-core/src/lib.rs
+++ b/crates/brace-web-core/src/lib.rs
@@ -1,0 +1,1 @@
+pub use actix_web::*;

--- a/crates/brace-web/Cargo.toml
+++ b/crates/brace-web/Cargo.toml
@@ -8,8 +8,10 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [features]
-default = ["markup"]
+default = ["core", "markup"]
+core = ["brace-web-core"]
 markup = ["brace-web-markup"]
 
 [dependencies]
+brace-web-core = { path = "../brace-web-core", optional = true }
 brace-web-markup = { path = "../brace-web-markup", optional = true }

--- a/crates/brace-web/src/lib.rs
+++ b/crates/brace-web/src/lib.rs
@@ -1,2 +1,5 @@
+#[cfg(feature = "core")]
+pub use brace_web_core as core;
+
 #[cfg(feature = "markup")]
 pub use brace_web_markup as markup;


### PR DESCRIPTION
This adds a `core` crate that simply re-exports the `actix-web` crate. This will allow other crates to use the `actix-web` project without having to specify it as a dependency in addition to `core`. It will also allow the `core` to grow and deviate from from `actix-web` over time.