### PR TITLE
Fix missing workspace member for core crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
   "crates/brace-web",
+  "crates/brace-web-core",
   "crates/brace-web-markup",
 ]


### PR DESCRIPTION
This adds the missing workspace member for the `core` crate.