### PR TITLE
Fix incorrect use of dev dependencies

### DIFF
--- a/crates/brace-web-core/Cargo.toml
+++ b/crates/brace-web-core/Cargo.toml
@@ -8,6 +8,8 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-actix-rt = "1.0"
 actix-web = "2.0"
 futures = "0.3"
+
+[dev-dependencies]
+actix-rt = "1.0"

--- a/crates/brace-web-form/Cargo.toml
+++ b/crates/brace-web-form/Cargo.toml
@@ -9,10 +9,12 @@ edition = "2018"
 
 [dependencies]
 actix-http = "1.0"
-actix-rt = "1.0"
 brace-web-core = { path = "../brace-web-core" }
 bytes = "0.5"
 encoding_rs = "0.8"
 futures = "0.3"
 serde = "1.0"
 serde_qs = "0.5"
+
+[dev-dependencies]
+actix-rt = "1.0"


### PR DESCRIPTION
This fixes the inclusion of `actix-rt` as a dependency when it is only required for tests.