### PR TITLE
Add parser for custom markup language

### DIFF
--- a/crates/brace-web-markup/Cargo.toml
+++ b/crates/brace-web-markup/Cargo.toml
@@ -8,5 +8,6 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
+brace-parser = { git = "https://github.com/brace-rs/brace-parser", rev = "c85faf303ac83ab5f2c5e529b7d6a559b2456a28" }
 indexmap = "1.2"
 lazy_static = "1.4"

--- a/crates/brace-web-markup/src/lib.rs
+++ b/crates/brace-web-markup/src/lib.rs
@@ -3,4 +3,5 @@ pub use crate::node::text::Text;
 pub use crate::node::Node;
 
 pub mod node;
+pub mod parser;
 pub mod render;

--- a/crates/brace-web-markup/src/node/element/attribute.rs
+++ b/crates/brace-web-markup/src/node/element/attribute.rs
@@ -4,7 +4,7 @@ use crate::node::element::Element;
 use crate::node::text::Text;
 use crate::node::{Node, Nodes};
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Attr {
     String(String),
     Boolean(bool),
@@ -175,7 +175,7 @@ impl From<Nodes> for Attr {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Attrs(pub(crate) IndexMap<String, Attr>);
 
 impl Attrs {
@@ -261,5 +261,17 @@ impl<'a> IntoIterator for &'a mut Attrs {
 impl From<()> for Attrs {
     fn from(_: ()) -> Self {
         Self::default()
+    }
+}
+
+impl From<Vec<(&str, Attr)>> for Attrs {
+    fn from(from: Vec<(&str, Attr)>) -> Self {
+        let mut attrs = Attrs::new();
+
+        for (name, attr) in from {
+            attrs.insert(name, attr);
+        }
+
+        attrs
     }
 }

--- a/crates/brace-web-markup/src/node/element/mod.rs
+++ b/crates/brace-web-markup/src/node/element/mod.rs
@@ -24,7 +24,7 @@ where
     Element::with(tag, attrs, nodes)
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Element(Attrs);
 
 impl Element {
@@ -194,6 +194,12 @@ impl From<&str> for Element {
 impl From<String> for Element {
     fn from(from: String) -> Self {
         Self::new(from)
+    }
+}
+
+impl From<(&str, Attrs, Nodes)> for Element {
+    fn from(from: (&str, Attrs, Nodes)) -> Self {
+        Self::with(from.0, from.1, from.2)
     }
 }
 

--- a/crates/brace-web-markup/src/node/mod.rs
+++ b/crates/brace-web-markup/src/node/mod.rs
@@ -255,16 +255,6 @@ impl From<Vec<Node>> for Nodes {
     }
 }
 
-impl From<Vec<Option<Node>>> for Nodes {
-    fn from(from: Vec<Option<Node>>) -> Self {
-        Self(
-            from.into_iter()
-                .filter_map(|x| x)
-                .collect::<VecDeque<Node>>(),
-        )
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::Nodes;

--- a/crates/brace-web-markup/src/node/mod.rs
+++ b/crates/brace-web-markup/src/node/mod.rs
@@ -7,7 +7,7 @@ use crate::render::{Render, Renderer, Result as RenderResult};
 pub mod element;
 pub mod text;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Node {
     Text(Text),
     Element(Element),
@@ -92,7 +92,7 @@ impl From<Element> for Node {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Nodes(VecDeque<Node>);
 
 impl Nodes {
@@ -252,6 +252,16 @@ impl From<&[Node]> for Nodes {
 impl From<Vec<Node>> for Nodes {
     fn from(from: Vec<Node>) -> Self {
         Self(from.into())
+    }
+}
+
+impl From<Vec<Option<Node>>> for Nodes {
+    fn from(from: Vec<Option<Node>>) -> Self {
+        Self(
+            from.into_iter()
+                .filter_map(|x| x)
+                .collect::<VecDeque<Node>>(),
+        )
     }
 }
 

--- a/crates/brace-web-markup/src/node/text.rs
+++ b/crates/brace-web-markup/src/node/text.rs
@@ -9,7 +9,7 @@ where
     Text::new(text)
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Text(String);
 
 impl Text {

--- a/crates/brace-web-markup/src/parser.rs
+++ b/crates/brace-web-markup/src/parser.rs
@@ -1,0 +1,812 @@
+use brace_parser::prelude::*;
+
+use crate::node::element::attribute::{Attr, Attrs};
+use crate::node::element::Element;
+use crate::node::text::Text;
+use crate::node::{Node, Nodes};
+
+pub fn document(input: &str) -> Output<Nodes> {
+    parse(
+        input,
+        context(
+            "document",
+            delimited(
+                optional(sequence::whitespace),
+                map(optional(nodes), Option::unwrap_or_default),
+                optional(sequence::whitespace),
+            ),
+        ),
+    )
+}
+
+pub fn newline(input: &str) -> Output<&str> {
+    parse(
+        input,
+        consume((
+            optional(sequence::indent),
+            sequence::linebreak,
+            optional(sequence::indent),
+        )),
+    )
+}
+
+pub fn string(input: &str) -> Output<String> {
+    parse(
+        input,
+        context(
+            "string",
+            delimited(
+                '"',
+                map(
+                    optional(unescape(
+                        escaped(
+                            not(either('"', character::linebreak)),
+                            branch(('"', '\\', 'n', 't', 'r', 'f')),
+                        ),
+                        branch((
+                            '"',
+                            '\\',
+                            map('n', |_| '\n'),
+                            map('t', |_| '\t'),
+                            map('r', |_| '\r'),
+                            map('f', |_| '\u{000C}'),
+                        )),
+                    )),
+                    Option::unwrap_or_default,
+                ),
+                fail('"'),
+            ),
+        ),
+    )
+}
+
+pub fn boolean(input: &str) -> Output<bool> {
+    parse(
+        input,
+        context(
+            "boolean",
+            either(map("true", |_| true), map("false", |_| false)),
+        ),
+    )
+}
+
+pub fn node(input: &str) -> Output<Node> {
+    parse(
+        input,
+        context(
+            "node",
+            either(map(text, Node::text), map(element, Node::element)),
+        ),
+    )
+}
+
+pub fn nodes(input: &str) -> Output<Nodes> {
+    parse(
+        input,
+        context("nodes", map(list(node, newline), Nodes::from)),
+    )
+}
+
+pub fn text(input: &str) -> Output<Text> {
+    parse(
+        input,
+        context(
+            "text",
+            map(
+                delimited(
+                    '"',
+                    map(
+                        optional(unescape(
+                            escaped(not('"'), branch(('"', '\\'))),
+                            branch(('"', '\\')),
+                        )),
+                        Option::unwrap_or_default,
+                    ),
+                    fail('"'),
+                ),
+                Text::from,
+            ),
+        ),
+    )
+}
+
+pub fn element(input: &str) -> Output<Element> {
+    parse(
+        input,
+        context(
+            "element",
+            map(
+                trio(
+                    tag,
+                    map(
+                        optional(leading(optional(sequence::indent), attributes)),
+                        Option::unwrap_or_default,
+                    ),
+                    map(
+                        optional(leading(optional(sequence::indent), body)),
+                        Option::unwrap_or_default,
+                    ),
+                ),
+                Element::from,
+            ),
+        ),
+    )
+}
+
+pub fn tag(input: &str) -> Output<&str> {
+    parse(
+        input,
+        context(
+            "tag",
+            trailing(
+                consume(list(
+                    (sequence::alphabetic, optional(sequence::alphanumeric)),
+                    '-',
+                )),
+                fail(peek(either(sequence::whitespace, end))),
+            ),
+        ),
+    )
+}
+
+pub fn body(input: &str) -> Output<Nodes> {
+    parse(
+        input,
+        context(
+            "body",
+            either(
+                leading(
+                    '|',
+                    fail(leading(optional(sequence::indent), map(node, Nodes::from))),
+                ),
+                delimited(
+                    '{',
+                    fail(delimited(
+                        optional(sequence::whitespace),
+                        map(optional(nodes), Option::unwrap_or_default),
+                        optional(sequence::whitespace),
+                    )),
+                    fail('}'),
+                ),
+            ),
+        ),
+    )
+}
+
+pub fn key(input: &str) -> Output<&str> {
+    parse(
+        input,
+        context("key", consume(list(sequence::alphabetic, '-'))),
+    )
+}
+
+pub fn attribute(input: &str) -> Output<Attr> {
+    parse(
+        input,
+        context(
+            "attribute",
+            either(map(string, Attr::string), map(boolean, Attr::boolean)),
+        ),
+    )
+}
+
+pub fn attributes(input: &str) -> Output<Attrs> {
+    parse(
+        input,
+        context(
+            "attributes",
+            map(
+                list(
+                    pair(
+                        key,
+                        map(
+                            optional(leading(
+                                leading(optional(sequence::indent), '='),
+                                fail(leading(optional(sequence::indent), attribute)),
+                            )),
+                            |attr| attr.unwrap_or_else(|| Attr::boolean(true)),
+                        ),
+                    ),
+                    (optional(sequence::indent), ',', optional(sequence::indent)),
+                ),
+                Attrs::from,
+            ),
+        ),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use brace_parser::sequence::Sequence;
+
+    #[test]
+    fn test_template() {
+        let lorem = r#"Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                Sed eget nunc rhoncus velit pretium viverra. Pellentesque tempor
+                lacus non diam convallis fermentum. Cras eu purus et massa
+                tincidunt rhoncus eget ut lectus. Nulla lacus lorem, consequat
+                quis pharetra at, gravida in turpis. Nullam iaculis dui ut felis
+                pretium euismod. In erat mauris, volutpat vel augue vel, finibus
+                eleifend dolor. Sed sodales porta ligula, vitae volutpat nulla."#;
+
+        assert_eq!(
+            parse(include_str!("../templates/example-001.txt"), document),
+            Ok((
+                Node::element(Element::new("html").attr("lang", "en").attr(
+                    "nodes",
+                    vec![
+                        Element::new("head").attr(
+                            "nodes",
+                            vec![
+                                    Element::new("meta").attr("charset", "utf-8"),
+                                    Element::new("title").attr("nodes", Text::new("Example 001")),
+                                    Element::new("meta")
+                                        .attr("name", "description")
+                                        .attr("content", "Example 001."),
+                                    Element::new("meta")
+                                        .attr("name", "author")
+                                        .attr("content", "Me"),
+                                    Element::new("link")
+                                        .attr("rel", "stylesheet")
+                                        .attr("href", "/assets/css/style.css"),
+                                    Element::new("script").attr("src", "/assets/js/script.js"),
+                                ]
+                        ),
+                        Element::new("body").attr(
+                            "nodes",
+                            vec![
+                                Element::new("header").attr(
+                                    "nodes",
+                                    Element::new("h1").attr("nodes", Text::new("Example 001"))
+                                ),
+                                Element::new("main").attr(
+                                    "nodes",
+                                    vec![
+                                        Element::new("p")
+                                            .attr("nodes", Text::new("This is example 001.")),
+                                        Element::new("p").attr("nodes", Text::new(lorem)),
+                                    ]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),)
+                .into(),
+                ""
+            )),
+        );
+        assert_eq!(
+            parse(include_str!("../templates/example-002.txt"), document),
+            Ok((
+                Node::element(
+                    Element::new("div")
+                        .attr("class", "field field--checkbox")
+                        .attr(
+                            "nodes",
+                            vec![
+                                Element::new("label")
+                                    .attr("for", "my-checkbox")
+                                    .attr("nodes", Text::new("Checkbox")),
+                                Element::new("input")
+                                    .attr("id", "my-checkbox")
+                                    .attr("class", "input input--checkbox")
+                                    .attr("type", "checkbox")
+                                    .attr("checked", true),
+                                Element::new("span")
+                                    .attr("class", "description")
+                                    .attr("nodes", Text::new("Description.")),
+                            ]
+                        ),
+                )
+                .into(),
+                ""
+            )),
+        );
+    }
+
+    #[test]
+    fn test_string() {
+        assert_eq!(
+            parse("", string),
+            Err(Error::expect('"').but_found_end().with_context("string"))
+        );
+        assert_eq!(
+            parse("hello", string),
+            Err(Error::expect('"').but_found('h').with_context("string"))
+        );
+        assert_eq!(
+            parse("\"", string),
+            Err(Error::expect('"')
+                .but_found_end()
+                .with_context("string")
+                .into_fail())
+        );
+        assert_eq!(parse("\"\"", string), Ok((String::new(), "")));
+        assert_eq!(parse("\"hello\"", string), Ok((String::from("hello"), "")));
+        assert_eq!(
+            parse("\"hello world\"", string),
+            Ok((String::from("hello world"), ""))
+        );
+        assert_eq!(
+            parse("\"hello\" world", string),
+            Ok((String::from("hello"), " world"))
+        );
+        assert_eq!(
+            parse("\"hello\" world\"", string),
+            Ok((String::from("hello"), " world\""))
+        );
+        assert_eq!(
+            parse("\"hello world", string),
+            Err(Error::expect('"')
+                .but_found_end()
+                .with_context("string")
+                .into_fail())
+        );
+        assert_eq!(
+            parse("hello world", string),
+            Err(Error::expect('"').but_found('h').with_context("string"))
+        );
+        assert_eq!(
+            parse("\"hello\nworld\"", string),
+            Err(Error::expect('"')
+                .but_found('\n')
+                .with_context("string")
+                .into_fail())
+        );
+        assert_eq!(
+            parse("\"hello\rworld\"", string),
+            Err(Error::expect('"')
+                .but_found('\r')
+                .with_context("string")
+                .into_fail())
+        );
+        assert_eq!(
+            parse("\"hello\x0Cworld\"", string),
+            Err(Error::expect('"')
+                .but_found('\x0C')
+                .with_context("string")
+                .into_fail())
+        );
+        assert_eq!(
+            parse("\"hello\tworld\"", string),
+            Ok((String::from("hello\tworld"), ""))
+        );
+        assert_eq!(
+            parse("\"hello\\\\world\"", string),
+            Ok((String::from("hello\\world"), ""))
+        );
+        assert_eq!(
+            parse("\"hello\\tworld\"", string),
+            Ok((String::from("hello\tworld"), ""))
+        );
+        assert_eq!(
+            parse("\"hello\\nworld\"", string),
+            Ok((String::from("hello\nworld"), ""))
+        );
+        assert_eq!(
+            parse("\"hello\\rworld\"", string),
+            Ok((String::from("hello\rworld"), ""))
+        );
+        assert_eq!(
+            parse("\"hello\\fworld\"", string),
+            Ok((String::from("hello\x0Cworld"), ""))
+        );
+        assert_eq!(
+            parse("\"\\\"hello world\\\"\"", string),
+            Ok((String::from("\"hello world\""), ""))
+        );
+        assert_eq!(
+            parse("\"\\\"\\\\\\\"hello world\\\\\\\"\\\"\"", string),
+            Ok((String::from("\"\\\"hello world\\\"\""), ""))
+        );
+        assert_eq!(
+            parse(
+                "\"\\\"\\\\\\\"\\\\\\\\\\\\\\\"hello world\\\\\\\\\\\\\\\"\\\\\\\"\\\"\"",
+                string
+            ),
+            Ok((String::from("\"\\\"\\\\\\\"hello world\\\\\\\"\\\"\""), ""))
+        );
+    }
+
+    #[test]
+    fn test_boolean() {
+        assert_eq!(
+            parse("", boolean),
+            Err(Error::expect('f').but_found_end().with_context("boolean"))
+        );
+        assert_eq!(parse("true", boolean), Ok((true, "")));
+        assert_eq!(parse("false", boolean), Ok((false, "")));
+        assert_eq!(
+            parse("null", boolean),
+            Err(Error::expect('f').but_found('n').with_context("boolean"))
+        );
+    }
+
+    #[test]
+    fn test_node() {
+        assert_eq!(parse("element", node), Ok((Node::element("element"), "")));
+        assert_eq!(parse("\"text\"", node), Ok((Node::text("text"), "")));
+        assert_eq!(
+            parse("div { span | \"text\" }", node),
+            Ok((
+                Element::new("div")
+                    .attr(
+                        "nodes",
+                        Element::new("span").attr("nodes", Text::new("text"))
+                    )
+                    .into(),
+                ""
+            ))
+        );
+        assert_eq!(
+            parse("div { span$ | \"text\" }", node),
+            Err(Error::expect(Expect::End)
+                .but_found('$')
+                .with_context("tag")
+                .into_fail())
+        );
+    }
+
+    #[test]
+    fn test_nodes() {
+        assert_eq!(
+            parse("element", nodes),
+            Ok((Node::element("element").into(), ""))
+        );
+        assert_eq!(
+            parse("\"text\"", nodes),
+            Ok((Node::text("text").into(), ""))
+        );
+        assert_eq!(
+            parse("element \n element", nodes),
+            Ok((
+                vec![Node::element("element"), Node::element("element")].into(),
+                ""
+            ))
+        );
+        assert_eq!(
+            parse("\"text\" \n \"text\"", nodes),
+            Ok((vec![Node::text("text"), Node::text("text")].into(), ""))
+        );
+        assert_eq!(
+            parse("div \n div", nodes),
+            Ok((vec![Element::new("div"), Element::new("div")].into(), ""))
+        );
+        assert_eq!(
+            parse("div {} \n div", nodes),
+            Ok((vec![Element::new("div"), Element::new("div")].into(), ""))
+        );
+        assert_eq!(
+            parse("div \n div {}", nodes),
+            Ok((vec![Element::new("div"), Element::new("div")].into(), ""))
+        );
+        assert_eq!(
+            parse("div {} \n div {}", nodes),
+            Ok((vec![Element::new("div"), Element::new("div")].into(), ""))
+        );
+        assert_eq!(
+            parse("div {} \n div { span | \"text\" }", nodes),
+            Ok((
+                vec![
+                    Element::new("div"),
+                    Element::new("div").attr(
+                        "nodes",
+                        Element::new("span").attr("nodes", Text::new("text"))
+                    )
+                ]
+                .into(),
+                ""
+            ))
+        );
+        assert_eq!(
+            parse("div {} \n div { span$ | \"text\" }", nodes),
+            Err(Error::expect(Expect::End)
+                .but_found('$')
+                .with_context("tag")
+                .into_fail())
+        );
+    }
+
+    #[test]
+    fn test_text() {
+        assert_eq!(
+            parse("", text),
+            Err(Error::expect('"').but_found_end().with_context("text"))
+        );
+        assert_eq!(
+            parse("hello", text),
+            Err(Error::expect('"').but_found('h').with_context("text"))
+        );
+        assert_eq!(
+            parse("\"", text),
+            Err(Error::expect('"')
+                .but_found_end()
+                .with_context("text")
+                .into_fail())
+        );
+        assert_eq!(parse("\"\"", text), Ok((Text::from(""), "")));
+        assert_eq!(parse("\"hello\"", text), Ok((Text::from("hello"), "")));
+        assert_eq!(
+            parse("\"hello world\"", text),
+            Ok((Text::from("hello world"), ""))
+        );
+        assert_eq!(
+            parse("\"hello\" world", text),
+            Ok((Text::from("hello"), " world"))
+        );
+        assert_eq!(
+            parse("\"hello\" world\"", text),
+            Ok((Text::from("hello"), " world\""))
+        );
+        assert_eq!(
+            parse("\"hello world", text),
+            Err(Error::expect('"')
+                .but_found_end()
+                .with_context("text")
+                .into_fail())
+        );
+        assert_eq!(
+            parse("hello world", text),
+            Err(Error::expect('"').but_found('h').with_context("text"))
+        );
+        assert_eq!(
+            parse("\"hello\nworld\"", text),
+            Ok((Text::from("hello\nworld"), ""))
+        );
+        assert_eq!(
+            parse("\"hello\rworld\"", text),
+            Ok((Text::from("hello\rworld"), ""))
+        );
+        assert_eq!(
+            parse("\"hello\x0Cworld\"", text),
+            Ok((Text::from("hello\x0cworld"), ""))
+        );
+        assert_eq!(
+            parse("\"hello\tworld\"", text),
+            Ok((Text::from("hello\tworld"), ""))
+        );
+        assert_eq!(
+            parse("\"hello\\\\world\"", text),
+            Ok((Text::from("hello\\world"), ""))
+        );
+        assert_eq!(
+            parse("\"hello\\tworld\"", text),
+            Err(Error::expect('"')
+                .but_found('h')
+                .with_context("text")
+                .into_fail())
+        );
+        assert_eq!(
+            parse("\"hello\\nworld\"", text),
+            Err(Error::expect('"')
+                .but_found('h')
+                .with_context("text")
+                .into_fail())
+        );
+        assert_eq!(
+            parse("\"hello\\rworld\"", text),
+            Err(Error::expect('"')
+                .but_found('h')
+                .with_context("text")
+                .into_fail())
+        );
+        assert_eq!(
+            parse("\"hello\\fworld\"", text),
+            Err(Error::expect('"')
+                .but_found('h')
+                .with_context("text")
+                .into_fail())
+        );
+        assert_eq!(
+            parse("\"\\\"hello world\\\"\"", text),
+            Ok((Text::from("\"hello world\""), ""))
+        );
+        assert_eq!(
+            parse("\"\\\"\\\\\\\"hello world\\\\\\\"\\\"\"", text),
+            Ok((Text::from("\"\\\"hello world\\\"\""), ""))
+        );
+        assert_eq!(
+            parse(
+                "\"\\\"\\\\\\\"\\\\\\\\\\\\\\\"hello world\\\\\\\\\\\\\\\"\\\\\\\"\\\"\"",
+                text
+            ),
+            Ok((Text::from("\"\\\"\\\\\\\"hello world\\\\\\\"\\\"\""), ""))
+        );
+    }
+
+    #[test]
+    fn test_element() {
+        assert_eq!(
+            parse("", element),
+            Err(Error::expect(Sequence::Alphabetic)
+                .but_found_end()
+                .with_context("tag"))
+        );
+        assert_eq!(parse("element", element), Ok((Element::new("element"), "")));
+        assert_eq!(
+            parse("element $", element),
+            Ok((Element::new("element"), " $"))
+        );
+        assert_eq!(
+            parse("element checked", element),
+            Ok((Element::new("element").attr("checked", true), ""))
+        );
+        assert_eq!(
+            parse("element class = \"custom\"", element),
+            Ok((Element::new("element").attr("class", "custom"), ""))
+        );
+        assert_eq!(
+            parse("element$", element),
+            Err(Error::expect(Expect::End)
+                .but_found('$')
+                .with_context("tag")
+                .into_fail())
+        );
+        assert_eq!(
+            parse("div { span | h$ | \"Title\" }", element),
+            Err(Error::expect(Expect::End)
+                .but_found('$')
+                .with_context("tag")
+                .into_fail())
+        );
+    }
+
+    #[test]
+    fn test_tag() {
+        assert_eq!(
+            parse("", tag),
+            Err(Error::expect(Sequence::Alphabetic)
+                .but_found_end()
+                .with_context("tag"))
+        );
+        assert_eq!(parse("custom", tag), Ok(("custom", "")));
+        assert_eq!(parse("custom-element", tag), Ok(("custom-element", "")));
+        assert_eq!(
+            parse("custom-element-inner", tag),
+            Ok(("custom-element-inner", ""))
+        );
+        assert_eq!(
+            parse("custom--element", tag),
+            Err(Error::expect(Expect::End)
+                .but_found('-')
+                .with_context("tag")
+                .into_fail())
+        );
+        assert_eq!(
+            parse("custom-element-", tag),
+            Err(Error::expect(Expect::End)
+                .but_found('-')
+                .with_context("tag")
+                .into_fail())
+        );
+        assert_eq!(
+            parse("-element", tag),
+            Err(Error::expect(sequence::Sequence::Alphabetic)
+                .but_found('-')
+                .with_context("tag"))
+        );
+    }
+
+    #[test]
+    fn test_body() {
+        assert_eq!(
+            parse("", body),
+            Err(Error::expect('{').but_found_end().with_context("body"))
+        );
+        assert_eq!(
+            parse("|", body),
+            Err(Error::expect(Sequence::Alphabetic)
+                .but_found_end()
+                .with_context("tag")
+                .into_fail())
+        );
+        assert_eq!(
+            parse("|\n", body),
+            Err(Error::expect(Sequence::Alphabetic)
+                .but_found('\n')
+                .with_context("tag")
+                .into_fail())
+        );
+        assert_eq!(
+            parse("{", body),
+            Err(Error::expect('}')
+                .but_found_end()
+                .with_context("body")
+                .into_fail())
+        );
+        assert_eq!(parse("{}", body), Ok((Nodes::new(), "")));
+        assert_eq!(
+            parse("| element", body),
+            Ok((Node::element("element").into(), ""))
+        );
+        assert_eq!(
+            parse("{ element }", body),
+            Ok((Node::element("element").into(), ""))
+        );
+        assert_eq!(
+            parse("{\n element \n}", body),
+            Ok((Node::element("element").into(), ""))
+        );
+    }
+
+    #[test]
+    fn test_attribute() {
+        assert_eq!(
+            parse("", attribute),
+            Err(Error::expect('f').but_found_end().with_context("boolean"))
+        );
+        assert_eq!(
+            parse("hello world", attribute),
+            Err(Error::expect('f').but_found('h').with_context("boolean"))
+        );
+        assert_eq!(
+            parse("\"hello world\"", attribute),
+            Ok((Attr::string("hello world"), ""))
+        );
+        assert_eq!(parse("true", attribute), Ok((Attr::boolean(true), "")));
+        assert_eq!(parse("false", attribute), Ok((Attr::boolean(false), "")));
+    }
+
+    #[test]
+    fn test_attributes() {
+        assert_eq!(
+            parse("one", attributes),
+            Ok((
+                {
+                    let mut attrs = Attrs::new();
+                    attrs.insert("one", true);
+                    attrs
+                },
+                ""
+            ))
+        );
+        assert_eq!(
+            parse("one, two", attributes),
+            Ok((
+                {
+                    let mut attrs = Attrs::new();
+                    attrs.insert("one", true);
+                    attrs.insert("two", true);
+                    attrs
+                },
+                ""
+            ))
+        );
+        assert_eq!(
+            parse("one = \"two\"", attributes),
+            Ok((
+                {
+                    let mut attrs = Attrs::new();
+                    attrs.insert("one", "two");
+                    attrs
+                },
+                ""
+            ))
+        );
+        assert_eq!(
+            parse("one = two", attributes),
+            Err(Error::expect('f')
+                .but_found('t')
+                .with_context("boolean")
+                .into_fail())
+        );
+        assert_eq!(
+            parse(
+                "one = \"hello\", two, three = true, four = false",
+                attributes
+            ),
+            Ok((
+                {
+                    let mut attrs = Attrs::new();
+                    attrs.insert("one", "hello");
+                    attrs.insert("two", true);
+                    attrs.insert("three", true);
+                    attrs.insert("four", false);
+                    attrs
+                },
+                ""
+            ))
+        );
+    }
+}

--- a/crates/brace-web-markup/templates/example-001.txt
+++ b/crates/brace-web-markup/templates/example-001.txt
@@ -1,0 +1,27 @@
+html lang = "en" {
+    head {
+        meta charset = "utf-8"
+        title | "Example 001"
+
+        meta name = "description", content = "Example 001."
+        meta name = "author", content = "Me"
+
+        link rel = "stylesheet", href = "/assets/css/style.css"
+        script src = "/assets/js/script.js"
+    }
+    body {
+        header | h1 | "Example 001"
+        main {
+            p | "This is example 001."
+            p {
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                Sed eget nunc rhoncus velit pretium viverra. Pellentesque tempor
+                lacus non diam convallis fermentum. Cras eu purus et massa
+                tincidunt rhoncus eget ut lectus. Nulla lacus lorem, consequat
+                quis pharetra at, gravida in turpis. Nullam iaculis dui ut felis
+                pretium euismod. In erat mauris, volutpat vel augue vel, finibus
+                eleifend dolor. Sed sodales porta ligula, vitae volutpat nulla."
+            }
+        }
+    }
+}

--- a/crates/brace-web-markup/templates/example-002.txt
+++ b/crates/brace-web-markup/templates/example-002.txt
@@ -1,0 +1,7 @@
+div class = "field field--checkbox" {
+    label for = "my-checkbox" | "Checkbox"
+    input id = "my-checkbox", class = "input input--checkbox", type = "checkbox", checked
+    span class = "description" {
+        "Description."
+    }
+}


### PR DESCRIPTION
This adds the initial version of a parser for a custom markup language that aims to replace the usage of `html` in the project. Once the details are worked out a comprehensive specification and related tooling can be built.