### PR TITLE
Add known HTML element support

### DIFF
--- a/crates/brace-web-markup/src/node/element.rs
+++ b/crates/brace-web-markup/src/node/element.rs
@@ -140,13 +140,21 @@ impl Render for Element {
             }
         }
 
-        write!(renderer, ">")?;
+        match self.tag() {
+            "area" | "base" | "br" | "col" | "command" | "embed" | "hr" | "img" | "input"
+            | "keygen" | "link" | "meta" | "param" | "source" | "track" | "wbr" => {
+                write!(renderer, " />")?;
+            }
+            _ => {
+                write!(renderer, ">")?;
 
-        for node in self.nodes() {
-            node.render(renderer)?;
+                for node in self.nodes() {
+                    node.render(renderer)?;
+                }
+
+                write!(renderer, "</{}>", self.tag())?;
+            }
         }
-
-        write!(renderer, "</{}>", self.tag())?;
 
         Ok(())
     }
@@ -202,6 +210,36 @@ impl From<(&str, Attributes, Nodes)> for Element {
     fn from(from: (&str, Attributes, Nodes)) -> Self {
         Self::new(from.0).with_attrs(from.1).with_nodes(from.2)
     }
+}
+
+macro_rules! elements {
+    ( $($name:ident)* ) => {
+        $(
+            #[cfg_attr(tarpaulin, skip)]
+            pub fn $name() -> Element {
+                Element::new(stringify!($name))
+            }
+        )*
+    };
+}
+
+elements! {
+    a abbr address area article aside audio b base bdi bdo blockquote body br button canvas caption
+    cite code col colgroup data datalist dd del details dfn dialog div dl dt em embed fieldset
+    figcaption figure footer form h1 h2 h3 h4 h5 h6 head header hgroup hr i iframe img input ins
+    kbd label legend li link main map mark menu menuitem meta meter nav noscript object ol optgroup
+    option output p param picture pre progress q rb rp rt rtc ruby s samp script section select
+    slot small source span strong style sub summary sup table tbody td template textarea tfoot th
+    thead time title tr track u ul var video wbr
+}
+
+elements! {
+    path circle ellipse line polygon polyline rect image
+}
+
+#[cfg_attr(tarpaulin, skip)]
+pub fn svg() -> Element {
+    Element::new("svg").with_attr("xmlns", "http://www.w3.org/2000/svg")
 }
 
 #[cfg(test)]

--- a/crates/brace-web-markup/src/render.rs
+++ b/crates/brace-web-markup/src/render.rs
@@ -90,14 +90,15 @@ mod tests {
             .as_element_mut()
             .unwrap()
             .nodes_mut()
-            .append(Node::element(
-                Element::new("head").with_node(Element::new("title").with_node("Hello world")),
-            ))
+            .append(Node::element(Element::new("head").with_nodes(vec![
+                Element::new("title").with_node("Hello world").into(),
+                Element::new("meta").with_attr("charset", "utf-8").into(),
+            ])))
             .append(Node::element(Element::new("body").with_node("hello world")));
 
         assert_eq!(
             render(node_2).unwrap(),
-            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Hello world</title></head><body>hello world</body></html>"
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Hello world</title><meta charset=\"utf-8\" /></head><body>hello world</body></html>"
         );
 
         let mut node_3 = Node::element("div");
@@ -127,7 +128,7 @@ mod tests {
 
         assert_eq!(
             render(node_4).unwrap(),
-            "<input type=\"checkbox\" checked></input>"
+            "<input type=\"checkbox\" checked />"
         );
     }
 }


### PR DESCRIPTION
This adds support for known HTML and SVG elements to facilitate building markup. This includes shortcut methods for creating a specific type of element and correctly rendering elements that must be empty.