### PR TITLE
Add request responder for nodes and elements

### DIFF
--- a/crates/brace-web-markup/Cargo.toml
+++ b/crates/brace-web-markup/Cargo.toml
@@ -9,4 +9,6 @@ edition = "2018"
 
 [dependencies]
 brace-parser = { git = "https://github.com/brace-rs/brace-parser", rev = "c85faf303ac83ab5f2c5e529b7d6a559b2456a28" }
+brace-web-core = { path = "../brace-web-core" }
+futures = "0.3"
 indexmap = "1.2"

--- a/crates/brace-web-markup/src/render.rs
+++ b/crates/brace-web-markup/src/render.rs
@@ -2,6 +2,9 @@ use std::error::Error as StdError;
 use std::fmt::{Display, Error as FmtError, Formatter, Result as FmtResult, Write};
 use std::result::Result as StdResult;
 
+use brace_web_core::dev::HttpResponseBuilder;
+use brace_web_core::{HttpResponse, ResponseError};
+
 pub type Result = StdResult<(), Error>;
 
 pub fn render<T>(item: T) -> StdResult<String, Error>
@@ -60,6 +63,14 @@ impl Display for Error {
 }
 
 impl StdError for Error {}
+
+impl ResponseError for Error {
+    fn error_response(&self) -> HttpResponse {
+        HttpResponseBuilder::new(self.status_code())
+            .content_type("text/html; charset=utf-8")
+            .body(self.to_string())
+    }
+}
 
 impl From<FmtError> for Error {
     fn from(from: FmtError) -> Self {


### PR DESCRIPTION
This implements the `Responder` trait for `Nodes`, `Node` and `Element` types.