### PR TITLE
Add document as markup root

### DIFF
--- a/crates/brace-web-markup/src/lib.rs
+++ b/crates/brace-web-markup/src/lib.rs
@@ -1,4 +1,5 @@
 pub use crate::node::attribute::Attribute;
+pub use crate::node::document::Document;
 pub use crate::node::element::Element;
 pub use crate::node::text::Text;
 pub use crate::node::Node;

--- a/crates/brace-web-markup/src/node/document.rs
+++ b/crates/brace-web-markup/src/node/document.rs
@@ -1,0 +1,126 @@
+use std::fmt::Write;
+
+use futures::future::{self, Ready};
+
+use brace_web_core::{HttpRequest, HttpResponse, Responder};
+
+use crate::node::{Node, Nodes};
+use crate::render::{render, Error, Render, Renderer, Result as RenderResult};
+
+pub fn document() -> Document {
+    Document::new()
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Document {
+    nodes: Nodes,
+}
+
+impl Document {
+    pub fn new() -> Self {
+        Self {
+            nodes: Nodes::new(),
+        }
+    }
+
+    pub fn nodes(&self) -> &Nodes {
+        &self.nodes
+    }
+
+    pub fn nodes_mut(&mut self) -> &mut Nodes {
+        &mut self.nodes
+    }
+
+    pub fn get_node(&self, index: usize) -> Option<&Node> {
+        self.nodes.get(index)
+    }
+
+    pub fn get_node_mut(&mut self, index: usize) -> Option<&mut Node> {
+        self.nodes.get_mut(index)
+    }
+
+    pub fn with_node<T>(mut self, node: T) -> Self
+    where
+        T: Into<Node>,
+    {
+        self.nodes.append(node.into());
+        self
+    }
+
+    pub fn with_nodes<T>(mut self, nodes: T) -> Self
+    where
+        T: IntoIterator<Item = Node>,
+    {
+        self.nodes.extend(nodes);
+        self
+    }
+}
+
+impl Render for Document {
+    fn render(&self, renderer: &mut Renderer) -> RenderResult {
+        write!(renderer, "<!DOCTYPE html>")?;
+
+        for node in &self.nodes {
+            node.render(renderer)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Responder for Document {
+    type Error = Error;
+    type Future = Ready<Result<HttpResponse, Self::Error>>;
+
+    fn respond_to(self, _: &HttpRequest) -> Self::Future {
+        match render(self) {
+            Ok(body) => future::ok(
+                HttpResponse::Ok()
+                    .content_type("text/html; charset=utf-8")
+                    .body(body),
+            ),
+            Err(err) => future::err(err),
+        }
+    }
+}
+
+impl From<Node> for Document {
+    fn from(node: Node) -> Self {
+        Self::new().with_node(node)
+    }
+}
+
+impl From<Nodes> for Document {
+    fn from(nodes: Nodes) -> Self {
+        Self::new().with_nodes(nodes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::node::document::Document;
+    use crate::node::element::Element;
+    use crate::node::text::Text;
+
+    #[test]
+    fn test_document_tree() {
+        let document = Document::new().with_node(
+            Element::new("html")
+                .with_node(Element::new("body").with_node(Text::new("hello world"))),
+        );
+
+        assert_eq!(document.nodes().len(), 1);
+
+        let html = document.nodes().get(0).unwrap();
+
+        assert_eq!(html.as_element().unwrap().nodes().len(), 1);
+
+        let body = html.as_element().unwrap().nodes().get(0).unwrap();
+
+        assert_eq!(body.as_element().unwrap().nodes().len(), 1);
+
+        let text = body.as_element().unwrap().nodes().get(0).unwrap();
+
+        assert_eq!(text.as_text().unwrap().value(), "hello world");
+    }
+}

--- a/crates/brace-web-markup/src/node/mod.rs
+++ b/crates/brace-web-markup/src/node/mod.rs
@@ -9,6 +9,7 @@ use self::text::Text;
 use crate::render::{render, Error, Render, Renderer, Result as RenderResult};
 
 pub mod attribute;
+pub mod document;
 pub mod element;
 pub mod text;
 

--- a/crates/brace-web-markup/src/parser.rs
+++ b/crates/brace-web-markup/src/parser.rs
@@ -1,19 +1,23 @@
 use brace_parser::prelude::*;
 
 use crate::node::attribute::{Attribute, Attributes};
+use crate::node::document::Document;
 use crate::node::element::Element;
 use crate::node::text::Text;
 use crate::node::{Node, Nodes};
 
-pub fn document(input: &str) -> Output<Nodes> {
+pub fn document(input: &str) -> Output<Document> {
     parse(
         input,
         context(
             "document",
-            delimited(
-                optional(sequence::whitespace),
-                map(optional(nodes), Option::unwrap_or_default),
-                optional(sequence::whitespace),
+            map(
+                delimited(
+                    optional(sequence::whitespace),
+                    map(optional(nodes), Option::unwrap_or_default),
+                    optional(sequence::whitespace),
+                ),
+                Document::from,
             ),
         ),
     )


### PR DESCRIPTION
This introduces the `Document` type to represent the root of a markup tree.