### PR TITLE
Update continuous integration workflow linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
     - master
+
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -27,7 +29,7 @@ jobs:
         args: --all -- --check
 
     - name: Clippy
-      uses: actions-rs/clippy-check@v1
+      uses: brace-rs/clippy-check@b75a09651cc90c3921c41888815fe6a7a0b0adae
       with:
         args: --all -- -D warnings
         name: Lint / Results
@@ -36,7 +38,6 @@ jobs:
   build:
     name: Build / ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
-    needs: lint
     strategy:
       matrix:
         target:
@@ -102,7 +103,6 @@ jobs:
   test:
     name: Test / ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
-    needs: lint
     strategy:
       matrix:
         target:
@@ -168,7 +168,6 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    needs: lint
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
This updates the continuous integration workflow linting job to fix the creation of unnamed workflows and disable lints on pushes to the master branch.