### PR TITLE
Add serde support for markup nodes

### DIFF
--- a/crates/brace-web-markup/Cargo.toml
+++ b/crates/brace-web-markup/Cargo.toml
@@ -11,4 +11,8 @@ edition = "2018"
 brace-parser = { git = "https://github.com/brace-rs/brace-parser", rev = "c85faf303ac83ab5f2c5e529b7d6a559b2456a28" }
 brace-web-core = { path = "../brace-web-core" }
 futures = "0.3"
-indexmap = "1.2"
+indexmap = { version = "1.2", features = ["serde-1"] }
+serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/crates/brace-web-markup/fixtures/serde.json
+++ b/crates/brace-web-markup/fixtures/serde.json
@@ -1,0 +1,27 @@
+{
+  "nodes": [
+    {
+      "tag": "html",
+      "attrs": {},
+      "nodes": [
+        {
+          "tag": "body",
+          "attrs": {
+            "greeting": true,
+            "message": "Hello world"
+          },
+          "nodes": [
+            "Hello",
+            {
+              "tag": "em",
+              "attrs": {},
+              "nodes": [
+                "world"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/crates/brace-web-markup/src/tree/document.rs
+++ b/crates/brace-web-markup/src/tree/document.rs
@@ -1,6 +1,7 @@
 use std::fmt::Write;
 
 use futures::future::{self, Ready};
+use serde::{Deserialize, Serialize};
 
 use brace_web_core::{HttpRequest, HttpResponse, Responder};
 
@@ -11,7 +12,7 @@ pub fn document() -> Document {
     Document::new()
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 pub struct Document {
     nodes: Nodes,
 }

--- a/crates/brace-web-markup/src/tree/element/attribute.rs
+++ b/crates/brace-web-markup/src/tree/element/attribute.rs
@@ -1,6 +1,8 @@
 use indexmap::map::{Entry, IndexMap, IntoIter, Iter, IterMut};
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(untagged)]
 pub enum Attribute {
     String(String),
     Boolean(bool),
@@ -100,7 +102,8 @@ impl From<bool> for Attribute {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+#[serde(transparent)]
 pub struct Attributes(IndexMap<String, Attribute>);
 
 impl Attributes {

--- a/crates/brace-web-markup/src/tree/element/mod.rs
+++ b/crates/brace-web-markup/src/tree/element/mod.rs
@@ -2,6 +2,7 @@ use std::fmt::Write;
 use std::ops::{Index, IndexMut};
 
 use futures::future::{self, Ready};
+use serde::{Deserialize, Serialize};
 
 use brace_web_core::{HttpRequest, HttpResponse, Responder};
 
@@ -18,7 +19,7 @@ where
     Element::new(tag)
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Element {
     tag: String,
     attrs: Attributes,

--- a/crates/brace-web-markup/src/tree/node.rs
+++ b/crates/brace-web-markup/src/tree/node.rs
@@ -1,13 +1,15 @@
 use std::collections::vec_deque::{IntoIter, Iter, IterMut, VecDeque};
 
 use futures::future::{self, Ready};
+use serde::{Deserialize, Serialize};
 
 use brace_web_core::{HttpRequest, HttpResponse, Responder};
 
 use crate::util::render::{render, Error, Render, Renderer, Result as RenderResult};
 use crate::{Element, Text};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(untagged)]
 pub enum Node {
     Text(Text),
     Element(Element),
@@ -120,7 +122,7 @@ impl From<Element> for Node {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 pub struct Nodes(VecDeque<Node>);
 
 impl Nodes {

--- a/crates/brace-web-markup/src/tree/text.rs
+++ b/crates/brace-web-markup/src/tree/text.rs
@@ -1,5 +1,7 @@
 use std::fmt::Write;
 
+use serde::{Deserialize, Serialize};
+
 use crate::util::render::{Render, Renderer, Result as RenderResult};
 
 pub fn text<T>(text: T) -> Text
@@ -9,7 +11,8 @@ where
     Text::new(text)
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(transparent)]
 pub struct Text(String);
 
 impl Text {

--- a/crates/brace-web-markup/tests/integration.rs
+++ b/crates/brace-web-markup/tests/integration.rs
@@ -1,0 +1,23 @@
+use brace_web_markup::{body, document, em, html, text, Document};
+use serde_json::{from_str, to_string_pretty};
+
+#[test]
+fn test_serde_integration() {
+    let doc = document().with_node(
+        html().with_node(
+            body()
+                .with_attr("greeting", true)
+                .with_attr("message", "Hello world")
+                .with_node(text("Hello"))
+                .with_node(em().with_node(text("world"))),
+        ),
+    );
+
+    let str_1 = to_string_pretty(&doc).unwrap();
+    let str_2 = include_str!("../fixtures/serde.json");
+
+    let doc_1: Document = from_str(&str_1).unwrap();
+    let doc_2: Document = from_str(&str_2).unwrap();
+
+    assert_eq!(doc_1, doc_2);
+}


### PR DESCRIPTION
This adds support for serialization and deserialization of markup nodes. This will allow generated markup to be stored in a database or file.